### PR TITLE
Allow CI to be manually triggered

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: PlatformIO CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
This adds `workflow_dispatch` to the list of events that trigger CI, so that it's possible to manually kick off a CI run for the main branch.