### PR TITLE
Led viewer merge - Disable PSRAM for default allocations unless its the Mesmerizer

### DIFF
--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -145,9 +145,9 @@ public:
     // show just one layer
     void ShowNoiseLayer(uint8_t layer, uint8_t colorrepeat, uint8_t colorshift)
     {
-        for (uint8_t i = 0; i < MATRIX_WIDTH; i++)
+        for (uint16_t i = 0; i < MATRIX_WIDTH; i++)
         {
-            for (uint8_t j = 0; j < MATRIX_HEIGHT; j++)
+            for (uint16_t j = 0; j < MATRIX_HEIGHT; j++)
             {
 
                 uint8_t color = g()->GetNoise().noise[i][j];

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -124,7 +124,7 @@ class PatternRose : public LEDStripEffect
       g()->DimAll(dim);
 
 
-      for (uint8_t i = 0; i < MATRIX_HEIGHT; i++)
+      for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
       {
         CRGB color;
 
@@ -281,8 +281,8 @@ public:
     virtual void Draw() override
     {
 
-        for (uint8_t x = 0; x < MATRIX_WIDTH; x++) {
-            for (uint8_t y = 0; y < MATRIX_HEIGHT; y++) {
+        for (uint16_t x = 0; x < MATRIX_WIDTH; x++) {
+            for (uint16_t y = 0; y < MATRIX_HEIGHT; y++) {
                 g()->leds[g()->xy(x, y)] =
                   (x ^ y ^ flip) < count ?
                       g()->ColorFromCurrentPalette(((x ^ y) << 2) + generation)

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -79,7 +79,7 @@ public:
     for (int x = 0; x < MATRIX_WIDTH; x++)
       g()->setPixel(x, 0, g()->getPixel(x, 1));
 
-    for (uint8_t i = 3; i < MATRIX_WIDTH - 3; i = i + 3)
+    for (uint16_t i = 3; i < MATRIX_WIDTH - 3; i = i + 3)
     {
       uint16_t color = g()->to16bit(g()->ColorFromCurrentPalette(i * 4));
       g()->drawCircle(i, 2, 1, color);
@@ -119,9 +119,9 @@ public:
       g()->setPixel(x, 0, g()->getPixel(x, 1));
 
     // draw grid of rainbow dots on top of the dimmed image
-    for (uint8_t y = 1; y < MATRIX_HEIGHT - 6; y = y + 6)
+    for (uint16_t y = 1; y < MATRIX_HEIGHT - 6; y = y + 6)
     {
-      for (uint8_t x = 1; x < MATRIX_WIDTH - 6; x = x + 6)
+      for (uint16_t x = 1; x < MATRIX_WIDTH - 6; x = x + 6)
       {
         g()->leds[g()->xy(x, y)] += g()->ColorFromCurrentPalette((x * y) / 2);
       }
@@ -155,13 +155,13 @@ public:
     g()->DimAll(10);
 
     // draw a rainbow color palette
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
+    for (uint16_t y = 0; y < MATRIX_HEIGHT; y++)
     {
-      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++)
+      for (uint16_t x = 0; x < MATRIX_CENTER_X; x++)
       {
         g()->leds[g()->xy(x, y)] += g()->ColorFromCurrentPalette(x * 8, y * 8 + 7);
       }
-      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++)
+      for (uint16_t x = 0; x < MATRIX_CENTER_X; x++)
       {
         g()->leds[g()->xy(MATRIX_WIDTH - 1 - x, y)] += g()->ColorFromCurrentPalette(x * 8, y * 8 + 7);
       }
@@ -215,7 +215,7 @@ public:
 
     for (uint8_t c = 0; c < 6; c++) {
       for (uint8_t j = 0; j < 5; j++) {
-        for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
+        for (uint16_t x = 0; x < MATRIX_WIDTH; x++)
         {
           g()->leds[g()->xy(x, y)] += rainbow[c];
         }

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -139,7 +139,7 @@ class PatternPongClock : public LEDStripEffect
         g->Clear();
 
         // draw pitch centre line
-        for (uint8_t i = 0; i < MATRIX_WIDTH / 2; i += 2)
+        for (uint16_t i = 0; i < MATRIX_WIDTH / 2; i += 2)
             g->setPixel(MATRIX_WIDTH / 2, i, 0x6666);
 
         // draw hh:mm seperator colon that blinks once per second

--- a/include/effects/matrix/PatternSpark.h
+++ b/include/effects/matrix/PatternSpark.h
@@ -89,7 +89,7 @@ class PatternSpark : public LEDStripEffect
       random16_add_entropy( random16());
 
       g()->DimAll(235);
-      for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
+      for (uint16_t x = 0; x < MATRIX_WIDTH; x++)
       {
         // Step 1.  Cool down every cell a little
         for (int y = 0; y < MATRIX_HEIGHT; y++) {

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -543,7 +543,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
         }
         else
         {
-            blurRows(g()->leds, MATRIX_WIDTH, MATRIX_HEIGHT, _blurFactor * 255);
+            g()->blurRows(g()->leds, MATRIX_WIDTH, MATRIX_HEIGHT, 0, _blurFactor * 255);
             fadeAllChannelsToBlackBy(55 * (2.0 - g_Analyzer._VURatioFade));
         }
 

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -71,21 +71,20 @@
 #include "effects/matrix/Vector.h"
 #include <memory>
 
-typedef struct 
+typedef struct
 {
     uint32_t noise_x;
     uint32_t noise_y;
     uint32_t noise_z;
     uint32_t noise_scale_x;
     uint32_t noise_scale_y;
-    uint8_t  noise[MATRIX_WIDTH][MATRIX_HEIGHT]; 
+    uint8_t  noise[MATRIX_WIDTH][MATRIX_HEIGHT];
     uint8_t  noisesmoothing;
 } Noise;
 
 class GFXBase : public Adafruit_GFX
 {
 protected:
-    
     size_t _width;
     size_t _height;
 
@@ -93,51 +92,55 @@ protected:
     static const uint8_t gamma6[];
 
     static const int _paletteCount = 10;
-    int              _paletteIndex = -1;
-    uint             _lastSecond = 99;
-    bool             _palettePaused = false;
+    int _paletteIndex = -1;
+    uint _lastSecond = 99;
+    bool _palettePaused = false;
 
-    TBlendType       _currentBlendType = LINEARBLEND;
-    CRGBPalette16    _currentPalette;
-    CRGBPalette16    _targetPalette;
-    String           _currentPaletteName;
-    
+    TBlendType _currentBlendType = LINEARBLEND;
+    CRGBPalette16 _currentPalette;
+    CRGBPalette16 _targetPalette;
+    String _currentPaletteName;
+
     std::unique_ptr<Noise> _ptrNoise;
 
     static const int _heatColorsPaletteIndex = 6;
     static const int _randomPaletteIndex = 9;
 
 public:
-
     // Many of the Aurora effects need direct access to these from external classes
 
-    CRGB * leds = nullptr;
-    std::unique_ptr<Boid []> _boids;
+    CRGB *leds = nullptr;
+    std::unique_ptr<Boid[]> _boids;
 
     GFXBase(int w, int h) : Adafruit_GFX(w, h),
                             _width(w),
                             _height(h)
     {
-        _boids.reset( psram_allocator<Boid>().allocate(_width) );
-        _ptrNoise.reset( psram_allocator<Noise>().allocate(1) );
+        debugV("Allocating boids and noise");
+        _boids.reset(psram_allocator<Boid>().allocate(_width));
+        _ptrNoise.reset(psram_allocator<Noise>().allocate(1));
         assert(_ptrNoise && _boids);
-        
+
+        debugV("Setting up palette");
         loadPalette(0);
+        debugV("Setting up noise");
         NoiseVariablesSetup();
+        debugV("Filling noise");
         FillGetNoise();
-        ResetOscillators();        
+        debugV("Done with GFXBase ctor");
+        ResetOscillators();
     }
 
     virtual ~GFXBase()
     {
     }
 
-    Noise & GetNoise()
+    Noise &GetNoise()
     {
         return *_ptrNoise;
     }
 
-    CRGBPalette16 & GetCurrentPalette()
+    CRGBPalette16 &GetCurrentPalette()
     {
         return _currentPalette;
     }
@@ -146,7 +149,7 @@ public:
     {
         return _width * _height;
     }
-    
+
     virtual CRGB getPixel(int16_t x, int16_t y) const
     {
         if (x >= 0 && x < _width && y >= 0 && y < _height)
@@ -155,7 +158,7 @@ public:
             throw std::runtime_error(str_sprintf("Invalid index in getPixel: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS).c_str());
     }
 
-    virtual CRGB getPixel(int16_t i) const 
+    virtual CRGB getPixel(int16_t i) const
     {
         if (i >= 0 && i < GetLEDCount())
             return leds[i];
@@ -173,7 +176,7 @@ public:
         return result;
     }
 
-    static uint8_t mapsin8(uint8_t theta, uint8_t lowest = 0, uint8_t highest = 255) 
+    static uint8_t mapsin8(uint8_t theta, uint8_t lowest = 0, uint8_t highest = 255)
     {
         uint8_t beatsin = sin8(theta);
         uint8_t rangewidth = highest - lowest;
@@ -182,7 +185,7 @@ public:
         return result;
     }
 
-    static uint8_t mapcos8(uint8_t theta, uint8_t lowest = 0, uint8_t highest = 255) 
+    static uint8_t mapcos8(uint8_t theta, uint8_t lowest = 0, uint8_t highest = 255)
     {
         uint8_t beatcos = cos8(theta);
         uint8_t rangewidth = highest - lowest;
@@ -222,7 +225,7 @@ public:
 
     // Matrices that are built from individually addressable strips like WS2812b generally
     // follow a boustrophodon layout as follows:
-    // 
+    //
     //     0 >  1 >  2 >  3 >  4
     //                         |
     //     9 <  8 <  7 <  6 <  5
@@ -233,9 +236,9 @@ public:
     //     |
     //    (etc)
     //
-    // If your matrix uses a different approach, you can override this function and implement it 
+    // If your matrix uses a different approach, you can override this function and implement it
     // in the xy() function of your class
-    
+
     virtual uint16_t xy(uint16_t x, uint16_t y) const
     {
         if (x & 0x01)
@@ -267,12 +270,12 @@ public:
         addColor(xy(x, y), from16Bit(color));
     }
 
-    virtual void fillLeds(std::unique_ptr<CRGB []> & pLEDs)
+    virtual void fillLeds(std::unique_ptr<CRGB[]> &pLEDs)
     {
         // A mesmerizer panel has the same layout as in memory, so we can memcpy.  Others may require transposition,
         // so we do it the "slow" way for other matrices
 
-        for (int x=0; x < _width; x++)
+        for (int x = 0; x < _width; x++)
             for (int y = 0; y < _height; y++)
                 setPixel(x, y, pLEDs[y * _width + x]);
     }
@@ -370,7 +373,7 @@ public:
         if (p >= 0 && p < GetLEDCount())
             for (int i = 0; i < NUM_CHANNELS; i++)
                 leds[(int)p] = bMerge ? leds[(int)p] + c1 : c1;
-                
+
         p = fPos + (1.0 - frac1);
         count -= (1.0 - frac1);
 
@@ -392,16 +395,15 @@ public:
                     leds[(int)p] = bMerge ? leds[(int)p] + c2 : c2;
     }
 
-
-    void blurRows(CRGB *leds, uint8_t width, uint8_t height, uint8_t first, fract8 blur_amount)
+    void blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)
     {
         // blur rows same as columns, for irregular matrix
         uint8_t keep = 255 - blur_amount;
         uint8_t seep = blur_amount >> 1;
-        for (uint8_t row = 0; row < height; row++)
+        for (uint16_t row = 0; row < height; row++)
         {
             CRGB carryover = CRGB::Black;
-            for (uint8_t i = first; i < width; i++)
+            for (uint16_t i = first; i < width; i++)
             {
                 CRGB cur = leds[xy(i, row)];
                 CRGB part = cur;
@@ -417,15 +419,15 @@ public:
     }
 
     // blurColumns: perform a blur1d on each column of a rectangular matrix
-    void blurColumns(CRGB *leds, uint8_t width, uint8_t height, uint8_t first, fract8 blur_amount)
+    void blurColumns(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)
     {
         // blur columns
         uint8_t keep = 255 - blur_amount;
         uint8_t seep = blur_amount >> 1;
-        for (uint8_t col = 0; col < width; ++col)
+        for (uint16_t col = 0; col < width; ++col)
         {
             CRGB carryover = CRGB::Black;
-            for (uint8_t i = first; i < height; ++i)
+            for (uint16_t i = first; i < height; ++i)
             {
                 CRGB cur = leds[xy(col, i)];
                 CRGB part = cur;
@@ -440,7 +442,7 @@ public:
         }
     }
 
-    void blur2d(CRGB *leds, uint8_t width, uint8_t firstColumn, uint8_t height, uint8_t firstRow, fract8 blur_amount)
+    void blur2d(CRGB *leds, uint16_t width, uint16_t firstColumn, uint16_t height, uint16_t firstRow, fract8 blur_amount)
     {
         blurRows(leds, width, height, firstColumn, blur_amount);
         blurColumns(leds, width, height, firstRow, blur_amount);
@@ -464,22 +466,34 @@ public:
 
         const int minutesPerPaletteCycle = 2;
         uint8_t secondHand = ((millis() / minutesPerPaletteCycle) / 1000) % 60;
-        
-        if( _lastSecond != secondHand) 
+
+        if (_lastSecond != secondHand)
         {
             _lastSecond = secondHand;
-            if( secondHand ==  0)  
-                { _targetPalette = RainbowColors_p; }
-            if( secondHand == 10)  
-                { _targetPalette = HeatColors_p; } // CRGBPalette16( g,g,b,b, p,p,b,b, g,g,b,b, p,p,b,b); }
-            if( secondHand == 20)  
-                { _targetPalette = ForestColors_p; } // CRGBPalette16( b,b,b,w, b,b,b,w, b,b,b,w, b,b,b,w); }
-            if( secondHand == 30)  
-                { _targetPalette = LavaColors_p; }       // Black gaps
-            if( secondHand == 40)  
-                { _targetPalette = CloudColors_p; }
-            if( secondHand == 50)  
-                { _targetPalette = PartyColors_p; }
+            if (secondHand == 0)
+            {
+                _targetPalette = RainbowColors_p;
+            }
+            if (secondHand == 10)
+            {
+                _targetPalette = HeatColors_p;
+            } // CRGBPalette16( g,g,b,b, p,p,b,b, g,g,b,b, p,p,b,b); }
+            if (secondHand == 20)
+            {
+                _targetPalette = ForestColors_p;
+            } // CRGBPalette16( b,b,b,w, b,b,b,w, b,b,b,w, b,b,b,w); }
+            if (secondHand == 30)
+            {
+                _targetPalette = LavaColors_p;
+            } // Black gaps
+            if (secondHand == 40)
+            {
+                _targetPalette = CloudColors_p;
+            }
+            if (secondHand == 50)
+            {
+                _targetPalette = PartyColors_p;
+            }
         }
     }
 
@@ -491,7 +505,7 @@ public:
     //   - the default of 24 is a good balance
     //   - meaningful values are 1-48.  1=veeeeeeeery slow, 48=quickest
     //   - "0" means do not change the currentPalette at all; freeze
-    
+
     void PausePalette(bool bPaused)
     {
         _palettePaused = bPaused;
@@ -500,14 +514,14 @@ public:
     bool IsPalettePaused()
     {
         return _palettePaused;
-    }    
+    }
 
     void UpdatePaletteCycle()
     {
 
         ChangePalettePeriodically();
-        uint8_t maxChanges = 24; 
-        nblendPaletteTowardPalette( _currentPalette, _targetPalette, maxChanges);
+        uint8_t maxChanges = 24;
+        nblendPaletteTowardPalette(_currentPalette, _targetPalette, maxChanges);
     }
 
     void RandomPalette()
@@ -661,8 +675,8 @@ public:
     }
 
     // write one pixel with the specified color from the current palette to coordinates
-    
-    void Pixel(int x, int y, uint8_t colorIndex) 
+
+    void Pixel(int x, int y, uint8_t colorIndex)
     {
         leds[xy(x, y)] = ColorFromCurrentPalette(colorIndex);
     }
@@ -676,7 +690,7 @@ public:
     uint8_t p[6];
 
     // set the speeds (and by that ratios) of the oscillators here
-    
+
     void MoveOscillators()
     {
         osci[0] = osci[0] + 5;
@@ -696,7 +710,7 @@ public:
     {
         memset(osci, 0, sizeof(osci));
         memset(p, 0, sizeof(p));
-    }    
+    }
 
     // All the caleidoscope functions work directly within the screenbuffer (leds array).
     // Draw whatever you like in the area x(0-15) and y (0-15) and then copy it arround.
@@ -810,7 +824,7 @@ public:
     //
     // create a square twister to the left or counter-clockwise
     // x and y for center, r for radius
-    
+
     void SpiralStream(int x, int y, int r, uint8_t dimm)
     {
         for (int d = r; d >= 0; d--)
@@ -978,7 +992,7 @@ public:
     }
 
     // give it a linear tail up and to the right
-    
+
     void StreamUpAndRight(uint8_t scale)
     {
         for (int x = 0; x < _width - 1; x++)
@@ -999,7 +1013,7 @@ public:
     }
 
     // just move everything one line down - BUGBUG (DAVEPL) Redundant with MoveX?
-    
+
     void MoveDown()
     {
         for (int y = _height - 1; y > 0; y--)
@@ -1012,8 +1026,8 @@ public:
     }
 
     // just move everything one line down - BUGBUG (davepl) Redundant with MoveY?
-    
-    void VerticalMoveFrom(int start, int end)  
+
+    void VerticalMoveFrom(int start, int end)
     {
         for (int y = end; y > start; y--)
         {
@@ -1026,7 +1040,7 @@ public:
 
     // copy the rectangle defined with 2 points x0, y0, x1, y1
     // to the rectangle beginning at x2, x3
-    
+
     void Copy(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2)
     {
         for (int y = y0; y < y1 + 1; y++)
@@ -1105,7 +1119,6 @@ public:
         BresenhamLine(x0, y0, x1, y1, ColorFromCurrentPalette(colorIndex), bMerge);
     }
 
-
     void drawLine(int x0, int y0, int x1, int y1, CRGB color)
     {
         BresenhamLine(x0, y0, x1, y1, color);
@@ -1118,7 +1131,7 @@ public:
             // if ((leds[i].r != 255) || (leds[i].g != 255) || (leds[i].b != 255))           // Don't dim pure white
             leds[i].nscale8(value);
         }
-    } 
+    }
     // write one pixel with the specified color from the current palette to coordinates
     /*
     void Pixel(int x, int y, uint8_t colorIndex) {
@@ -1162,15 +1175,15 @@ public:
 
     void FillGetNoise()
     {
-        for (uint8_t i = 0; i < _width; i++)
+        for (uint16_t i = 0; i < _width; i++)
         {
             uint32_t ioffset = _ptrNoise->noise_scale_x * (i - ((_height + 1) / 2));
 
-            for (uint8_t j = 0; j < _height; j++)
+            for (uint16_t j = 0; j < _height; j++)
             {
                 uint32_t joffset = _ptrNoise->noise_scale_y * (j - ((_height + 1) / 2));
 
-                uint8_t data = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
+                uint16_t data = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
 
                 uint8_t olddata = _ptrNoise->noise[i][j];
                 uint8_t newdata = scale8(olddata, _ptrNoise->noisesmoothing) + scale8(data, 256 - _ptrNoise->noisesmoothing);
@@ -1200,19 +1213,19 @@ public:
             for (int x = 0; x < _width / 2 - 1; x++)
             {
                 leds[xy(x, y)] = leds[xy(x + 1, y)];
-                leds[xy(_width-x-1, y)] = leds[xy(_width-x-2, y)];
+                leds[xy(_width - x - 1, y)] = leds[xy(_width - x - 2, y)];
             }
-        }    
+        }
     }
 
     // MoveX - Shift the content on the matrix left or right
-    
+
     void MoveX(uint8_t delta)
     {
         for (int y = 0; y < _height; y++)
         {
             // First part
-            for (int x = 0; x < _width - delta; x++)  
+            for (int x = 0; x < _width - delta; x++)
                 leds[xy(x, y)] = leds[xy(x + delta, y)];
             // Wrap around to second part
             for (int x = _width - delta; x < _width; x++)
@@ -1221,7 +1234,7 @@ public:
     }
 
     // MoveY - Shifts the content on the matix up or down
-    
+
     void MoveY(uint8_t delta)
     {
         CRGB tmp = 0;
@@ -1241,7 +1254,7 @@ public:
 
     void MoveFractionalNoiseX(uint8_t amt = 16)
     {
-        std::unique_ptr<CRGB []> ledsTemp = std::make_unique<CRGB []>(NUM_LEDS);
+        std::unique_ptr<CRGB[]> ledsTemp = std::make_unique<CRGB[]>(NUM_LEDS);
 
         // move delta pixelwise
         for (int y = 0; y < _height; y++)
@@ -1262,13 +1275,13 @@ public:
         CRGB PixelA;
         CRGB PixelB;
 
-        for (uint8_t y = 0; y < _height; y++)
+        for (uint16_t y = 0; y < _height; y++)
         {
-            uint16_t amount   = _ptrNoise->noise[0][y] * amt;
-            uint8_t delta     = _height - 1 - (amount / 256);
+            uint16_t amount = _ptrNoise->noise[0][y] * amt;
+            uint8_t delta = _height - 1 - (amount / 256);
             uint8_t fractions = amount - (delta * 256);
 
-            for (uint8_t x = 1; x < _width; x++)
+            for (uint16_t x = 1; x < _width; x++)
             {
                 PixelA = ledsTemp[xy(x, y)];
                 PixelB = ledsTemp[xy(x - 1, y)];
@@ -1291,7 +1304,7 @@ public:
 
     void MoveFractionalNoiseY(uint8_t amt = 16)
     {
-        std::unique_ptr<CRGB []> ledsTemp = std::make_unique<CRGB []>(NUM_LEDS);
+        std::unique_ptr<CRGB[]> ledsTemp = std::make_unique<CRGB[]>(NUM_LEDS);
 
         // move delta pixelwise
         for (int x = 0; x < _width; x++)
@@ -1313,13 +1326,13 @@ public:
         CRGB PixelA;
         CRGB PixelB;
 
-        for (uint8_t x = 0; x < _width; x++)
+        for (uint16_t x = 0; x < _width; x++)
         {
             uint16_t amount = _ptrNoise->noise[x][0] * amt;
             uint8_t delta = _height - 1 - (amount / 256);
             uint8_t fractions = amount - (delta * 256);
 
-            for (uint8_t y = 1; y < _height; y++)
+            for (uint16_t y = 1; y < _height; y++)
             {
                 PixelA = ledsTemp[xy(x, y)];
                 PixelB = ledsTemp[xy(x, y - 1)];

--- a/include/globals.h
+++ b/include/globals.h
@@ -705,7 +705,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TIME_BEFORE_LOCAL       5   // How many seconds before the lamp times out and shows local content
 
     #define NUM_CHANNELS    1
-    #define MATRIX_WIDTH    (8*144)       // My naximum run, and about all you can do at 30fps
+    #define MATRIX_WIDTH    (8*144)     // My maximum run, and about all you can do at 30fps
     #define MATRIX_HEIGHT   1
     #define NUM_LEDS        (MATRIX_WIDTH * MATRIX_HEIGHT)
     #define ENABLE_REMOTE   0                     // IR Remote Control
@@ -1052,9 +1052,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #define STACK_SIZE (ESP_TASK_MAIN_STACK) // Stack size for each new thread
 #define TIME_CHECK_INTERVAL_MS (1000 * 60 * 5)   // How often in ms we resync the clock from NTP
-#define MIN_BRIGHTNESS  4
+#define MIN_BRIGHTNESS  10
 #define MAX_BRIGHTNESS  255
-#define BRIGHTNESS_STEP 10          // Amount to step brightness on each remote control repeat
+#define BRIGHTNESS_STEP 20          // Amount to step brightness on each remote control repeat
 #define MAX_RINGS       5
 
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -43,6 +43,7 @@ public:
 
     LEDStripGFX(size_t w, size_t h) : GFXBase(w, h)
     {
+        debugV("Creating Device of size %d x %d", w, h);
         leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
         if(!leds)
             throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");

--- a/include/remotecontrol.h
+++ b/include/remotecontrol.h
@@ -190,22 +190,7 @@ class RemoteControl
         if (0xFFFFFFFF == result)
         {
             debugV("Remote Repeat; lastResult == %08x\n", lastResult);
-            if (lastResult == IR_BMINUS)
-            {
-                g_Brightness = std::max(MIN_BRIGHTNESS, g_Brightness - BRIGHTNESS_STEP);
-                debugV("Dimming to %d\n", g_Brightness);
-                return;
-            }
-            else if (lastResult == IR_BPLUS)
-            {
-                g_Brightness = std::min(MAX_BRIGHTNESS, g_Brightness + BRIGHTNESS_STEP);
-                debugV("Brightening to %d\n", g_Brightness);
-                return;
-            }
-        }
-        else
-        {
-            lastResult = result;
+            result = lastResult;
         }
 
         if (IR_ON == result)
@@ -215,6 +200,11 @@ class RemoteControl
             g_ptrEffectManager->SetInterval(0);
             g_ptrEffectManager->StartEffect();
             g_Brightness = 255;
+            return;
+        }
+        else if (IR_OFF == result)
+        {
+            g_Brightness = std::max(MIN_BRIGHTNESS, (int) g_Brightness - BRIGHTNESS_STEP);
             return;
         }
         else if (IR_BPLUS == result)

--- a/include/screen.h
+++ b/include/screen.h
@@ -88,7 +88,7 @@ class Screen
     // 
     // Display a single string of text on the TFT screen, useful during boot for status, etc.
 
-    static void IRAM_ATTR ScreenStatus(const String & strStatus)
+    static inline void ScreenStatus(const String & strStatus)
     {
     #if USE_OLED 
         g_pDisplay->clear();
@@ -99,7 +99,7 @@ class Screen
         g_pDisplay->sendBuffer();
     #elif USE_TFTSPI || USE_M5DISPLAY
         g_pDisplay->fillScreen(TFT_BLACK);
-        g_pDisplay->setFreeFont(FF15);
+        g_pDisplay->setFreeFont(FF1);
         g_pDisplay->setTextColor(0xFBE0);
         auto xh = 10;
         auto yh = 0; 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = mesmerizer
+default_envs = ledstrip_feather
 
 ; ==================
 ; Base configuration
@@ -327,6 +327,8 @@ build_flags     = -DLEDSTRIP=1
                   ${psram_flags.build_flags}
                   ${unity_double_flags.build_flags}
                   ${dev_adafruit_feather.build_flags}
+upload_port = /dev/cu.usbmodem8411101
+monitor_port = /dev/cu.usbmodem8411101
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover

--- a/platformio.ini
+++ b/platformio.ini
@@ -327,8 +327,6 @@ build_flags     = -DLEDSTRIP=1
                   ${psram_flags.build_flags}
                   ${unity_double_flags.build_flags}
                   ${dev_adafruit_feather.build_flags}
-upload_port = /dev/cu.usbmodem8411101
-monitor_port = /dev/cu.usbmodem8411101
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -98,7 +98,12 @@ void MatrixPreDraw()
 
         auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(graphics);
         pMatrix->setLeds(LEDMatrixGFX::GetMatrixBackBuffer());
-        pMatrix->SetBrightness(g_Fader);
+
+        // We set ouutselves to the lower of the fader value or the brightness value, 
+        // so that we can fade between effects without having to change the brightness
+        // setting. 
+
+        pMatrix->SetBrightness(min(g_Brightness, g_Fader));
 
         if (g_ptrEffectManager->GetCurrentEffect()->ShouldShowTitle() && pMatrix->GetCaptionTransparency() > 0.00)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -604,21 +604,30 @@ void setup()
 
     // Initialize the strand controllers depending on how many channels we have
 
-    #ifdef USESTRIP
+    Screen::ScreenStatus("Initializing GFXBASE devices");
+
+    #if USESTRIP
         for (int i = 0; i < NUM_CHANNELS; i++)
-            g_aptrDevices[i] = std::make_unique<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
+        {
+            debugW("Allocating LEDStripGFX for channel %d", i);
+            g_aptrDevices[i] = std::make_shared<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
+        }
     #endif
 
     #if USE_MATRIX
         for (int i = 0; i < NUM_CHANNELS; i++)
         {
-            g_aptrDevices[i] = std::make_unique<LEDMatrixGFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
+            g_aptrDevices[i] = std::make_shared<LEDMatrixGFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
             g_aptrDevices[i]->loadPalette(0);
         }
     #endif
 
+    Screen::ScreenStatus("Setting JPG callback");
+
     TJpgDec.setJpgScale(1);
     TJpgDec.setCallback(bitmap_output);
+
+    Screen::ScreenStatus("Allocating LED Buffers");
 
     #if USE_PSRAM
         uint32_t memtouse = ESP.getFreePsram() - RESERVE_MEMORY;
@@ -661,6 +670,8 @@ void setup()
         ledcSetup(2, 12000, 8);
         ledcSetup(3, 12000, 8);
     #endif
+
+    Screen::ScreenStatus("Initializing LED strips");
 
     #if USESTRIP
 
@@ -726,6 +737,8 @@ void setup()
         #endif
     #endif
 
+    Screen::ScreenStatus("Initializing Effects Manager");
+
     // Show splash effect on matrix
     #if USE_MATRIX
         debugI("Initializing splash effect manager...");
@@ -735,6 +748,8 @@ void setup()
         InitEffectsManager();
     #endif
 
+    Screen::ScreenStatus("Initializing Audio");
+
     // Microphone stuff
     #if ENABLE_AUDIO
         pinMode(INPUT_PIN, INPUT);
@@ -742,6 +757,8 @@ void setup()
         g_TaskManager.StartAudioThread();
         CheckHeap();
     #endif
+
+    Screen::ScreenStatus("Initializing Screen Thread");
 
     #if USE_SCREEN
         g_TaskManager.StartScreenThread();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -214,19 +214,21 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         for (uint iPass = 0; iPass < cRetries; iPass++)
         {
-            Serial.printf("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-                iPass + 1, cRetries, WiFi_ssid, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+            debugV("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
+                    iPass + 1, cRetries, WiFi_ssid, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
 
             WiFi.disconnect();
             WiFi.mode(WIFI_STA);
             WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
+
+            debugV("Done Wifi.begin, waiting for connection...");
 
             // Give the module a few seconds to connect
             delay(4000 + iPass * 1000);
 
             if (WiFi.isConnected())
             {
-                Serial.printf("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
+                debugV("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
                 break;
             }
         }


### PR DESCRIPTION
Disable PSRAM for default allocations unless its the Mesmerizer.  This also fixes a number of range bugs where the matrix was always assumed to be 8-bit max width.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).